### PR TITLE
Fix spelling in new project dialog

### DIFF
--- a/Views/NewView.xaml.cs
+++ b/Views/NewView.xaml.cs
@@ -77,7 +77,7 @@ namespace PhaserIDE.Views
         {
             using (var dialog = new FolderBrowserDialog())
             {
-                dialog.Description = "Chose target folder:";
+                dialog.Description = "Choose target folder:";
                 if (dialog.ShowDialog() == DialogResult.OK)
                 {
                     TargetFolderBox.Text = dialog.SelectedPath;


### PR DESCRIPTION
## Summary
- fix a typo in the description for choosing the target folder

## Testing
- `grep -rn "Chose target folder" .`


------
https://chatgpt.com/codex/tasks/task_e_684498353a28832fb806ce92d715fd86